### PR TITLE
changed return type to mixed fixing swagger doc breaks

### DIFF
--- a/app/code/Anymarket/Anymarket/Api/FeedManagementInterface.php
+++ b/app/code/Anymarket/Anymarket/Api/FeedManagementInterface.php
@@ -8,7 +8,7 @@ interface FeedManagementInterface
     /**
      * Get Order Control from Anymarket
      * @param int $typeFeed
-     * @return array
+     * @return mixed[]
      */
     public function getFeedByType($typeFeed);
 

--- a/app/code/Anymarket/Anymarket/Api/OrderControlManagementInterface.php
+++ b/app/code/Anymarket/Anymarket/Api/OrderControlManagementInterface.php
@@ -16,7 +16,7 @@ interface OrderControlManagementInterface
     /**
      * Get Order Control from Anymarket
      * @param int $idAnymarket
-     * @return array
+     * @return mixed[]
      */
     public function getOrderByIdAnymarket($idAnymarket);
 

--- a/app/code/Anymarket/Anymarket/Api/PaymentMethodInterface.php
+++ b/app/code/Anymarket/Anymarket/Api/PaymentMethodInterface.php
@@ -14,7 +14,7 @@ interface PaymentMethodInterface
     /**
      * Get payment methods
      *
-     * @return array
+     * @return mixed[]
      */
     public function getPaymentMethods();
 }

--- a/app/code/Anymarket/Anymarket/Api/ShippingMethodInterface.php
+++ b/app/code/Anymarket/Anymarket/Api/ShippingMethodInterface.php
@@ -14,7 +14,7 @@ interface ShippingMethodInterface
     /**
      * Get shipping methods
      *
-     * @return array
+     * @return mixed[]
      */
     public function getShippingMethods();
 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| **Issue**         | https://github.com/AnyMarket/magento2/issues/3
| **What?**         | Changed the interface method doc.
| **Why?**          | This cause errors on swagger API default Magento doc
| **How?**          | Changed the interface doc from array (Magento unsupported) to mixed[] for swagger API doc.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### :package: Attachments (if appropriate)

After changed array to mixed[] it's possible to get all the API endpoints docs (collapsed on print)

![Screenshot at Oct 10 17-12-41](https://user-images.githubusercontent.com/405469/66603118-d518ed80-eb81-11e9-8018-e90a13cf8f6a.png)


And access the swagger docs:

![Screenshot at Oct 10 17-19-00](https://user-images.githubusercontent.com/405469/66603215-13161180-eb82-11e9-9d3d-78c3d9e4423e.png)


